### PR TITLE
feat(core): Add comprehensive unit tests for recap-core

### DIFF
--- a/web/crates/recap-core/src/services/session_parser.rs
+++ b/web/crates/recap-core/src/services/session_parser.rs
@@ -309,6 +309,12 @@ pub fn parse_session_full(path: &PathBuf) -> Option<ParsedSession> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    // ========================================================================
+    // generate_daily_hash Tests
+    // ========================================================================
 
     #[test]
     fn test_generate_daily_hash_consistent() {
@@ -323,6 +329,32 @@ mod tests {
         let hash2 = generate_daily_hash("user1", "/home/project", "2026-01-12");
         assert_ne!(hash1, hash2, "Different dates should produce different hashes");
     }
+
+    #[test]
+    fn test_generate_daily_hash_different_users() {
+        let hash1 = generate_daily_hash("user1", "/home/project", "2026-01-11");
+        let hash2 = generate_daily_hash("user2", "/home/project", "2026-01-11");
+        assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_generate_daily_hash_different_projects() {
+        let hash1 = generate_daily_hash("user1", "/home/project1", "2026-01-11");
+        let hash2 = generate_daily_hash("user1", "/home/project2", "2026-01-11");
+        assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_generate_daily_hash_format() {
+        let hash = generate_daily_hash("user", "project", "2026-01-15");
+        // SHA256 hash should be 64 hex characters
+        assert_eq!(hash.len(), 64);
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    // ========================================================================
+    // is_meaningful_message Tests
+    // ========================================================================
 
     #[test]
     fn test_is_meaningful_message_valid() {
@@ -350,6 +382,31 @@ mod tests {
     }
 
     #[test]
+    fn test_is_meaningful_message_exact_boundary() {
+        // Exactly 10 characters should be meaningful
+        assert!(is_meaningful_message("1234567890"));
+        // 9 characters should not be meaningful
+        assert!(!is_meaningful_message("123456789"));
+    }
+
+    #[test]
+    fn test_is_meaningful_message_whitespace() {
+        // Whitespace should be trimmed
+        assert!(!is_meaningful_message("   short   "));
+        assert!(is_meaningful_message("   1234567890   "));
+    }
+
+    #[test]
+    fn test_is_meaningful_message_case_insensitive() {
+        assert!(!is_meaningful_message("WARMUP"));
+        assert!(!is_meaningful_message("WaRmUp"));
+    }
+
+    // ========================================================================
+    // extract_tool_detail Tests
+    // ========================================================================
+
+    #[test]
     fn test_extract_tool_detail_edit() {
         let input = serde_json::json!({
             "file_path": "/home/user/project/src/main.rs"
@@ -357,6 +414,47 @@ mod tests {
         let detail = extract_tool_detail("Edit", &input);
         assert!(detail.is_some());
         assert!(detail.unwrap().contains("main.rs"));
+    }
+
+    #[test]
+    fn test_extract_tool_detail_write() {
+        let input = serde_json::json!({
+            "file_path": "/home/user/project/README.md"
+        });
+        let detail = extract_tool_detail("Write", &input);
+        assert!(detail.is_some());
+        assert!(detail.unwrap().contains("README.md"));
+    }
+
+    #[test]
+    fn test_extract_tool_detail_read() {
+        let input = serde_json::json!({
+            "file_path": "/home/user/project/config.json"
+        });
+        let detail = extract_tool_detail("Read", &input);
+        assert!(detail.is_some());
+        assert!(detail.unwrap().contains("config.json"));
+    }
+
+    #[test]
+    fn test_extract_tool_detail_short_path() {
+        let input = serde_json::json!({
+            "file_path": "src/main.rs"
+        });
+        let detail = extract_tool_detail("Edit", &input);
+        assert_eq!(detail, Some("src/main.rs".to_string()));
+    }
+
+    #[test]
+    fn test_extract_tool_detail_long_path() {
+        let input = serde_json::json!({
+            "file_path": "/home/user/projects/myapp/src/components/Button.tsx"
+        });
+        let detail = extract_tool_detail("Edit", &input);
+        assert!(detail.is_some());
+        let detail = detail.unwrap();
+        // Should truncate to last 3 parts with .../ prefix
+        assert!(detail.starts_with(".../"));
     }
 
     #[test]
@@ -379,5 +477,360 @@ mod tests {
         let detail = detail.unwrap();
         assert!(detail.len() <= 63); // 60 + "..."
         assert!(detail.ends_with("..."));
+    }
+
+    #[test]
+    fn test_extract_tool_detail_glob() {
+        let input = serde_json::json!({
+            "pattern": "**/*.rs"
+        });
+        let detail = extract_tool_detail("Glob", &input);
+        assert_eq!(detail, Some("**/*.rs".to_string()));
+    }
+
+    #[test]
+    fn test_extract_tool_detail_grep() {
+        let input = serde_json::json!({
+            "pattern": "fn main"
+        });
+        let detail = extract_tool_detail("Grep", &input);
+        assert_eq!(detail, Some("fn main".to_string()));
+    }
+
+    #[test]
+    fn test_extract_tool_detail_task() {
+        let input = serde_json::json!({
+            "description": "Explore codebase"
+        });
+        let detail = extract_tool_detail("Task", &input);
+        assert_eq!(detail, Some("Explore codebase".to_string()));
+    }
+
+    #[test]
+    fn test_extract_tool_detail_task_long_description() {
+        let long_desc = "a".repeat(100);
+        let input = serde_json::json!({
+            "description": long_desc
+        });
+        let detail = extract_tool_detail("Task", &input);
+        assert!(detail.is_some());
+        assert_eq!(detail.unwrap().len(), 50);
+    }
+
+    #[test]
+    fn test_extract_tool_detail_unknown_tool() {
+        let input = serde_json::json!({
+            "some_field": "value"
+        });
+        let detail = extract_tool_detail("UnknownTool", &input);
+        assert!(detail.is_none());
+    }
+
+    #[test]
+    fn test_extract_tool_detail_missing_field() {
+        let input = serde_json::json!({
+            "other_field": "value"
+        });
+        let detail = extract_tool_detail("Edit", &input);
+        assert!(detail.is_none());
+    }
+
+    // ========================================================================
+    // ToolUsage Tests
+    // ========================================================================
+
+    #[test]
+    fn test_tool_usage_creation() {
+        let usage = ToolUsage {
+            tool_name: "Edit".to_string(),
+            count: 5,
+        };
+
+        assert_eq!(usage.tool_name, "Edit");
+        assert_eq!(usage.count, 5);
+    }
+
+    #[test]
+    fn test_tool_usage_clone() {
+        let usage = ToolUsage {
+            tool_name: "Bash".to_string(),
+            count: 10,
+        };
+
+        let cloned = usage.clone();
+
+        assert_eq!(usage.tool_name, cloned.tool_name);
+        assert_eq!(usage.count, cloned.count);
+    }
+
+    // ========================================================================
+    // SessionMetadata Tests
+    // ========================================================================
+
+    #[test]
+    fn test_session_metadata_creation() {
+        let metadata = SessionMetadata {
+            cwd: Some("/home/user/project".to_string()),
+            first_ts: "2026-01-15T10:00:00Z".to_string(),
+            last_ts: "2026-01-15T12:00:00Z".to_string(),
+            first_msg: Some("Help me fix this bug".to_string()),
+            message_count: 5,
+        };
+
+        assert_eq!(metadata.cwd, Some("/home/user/project".to_string()));
+        assert_eq!(metadata.first_ts, "2026-01-15T10:00:00Z");
+        assert_eq!(metadata.message_count, 5);
+    }
+
+    #[test]
+    fn test_session_metadata_clone() {
+        let metadata = SessionMetadata {
+            cwd: Some("/path".to_string()),
+            first_ts: "2026-01-15T10:00:00Z".to_string(),
+            last_ts: "2026-01-15T11:00:00Z".to_string(),
+            first_msg: None,
+            message_count: 3,
+        };
+
+        let cloned = metadata.clone();
+
+        assert_eq!(metadata.cwd, cloned.cwd);
+        assert_eq!(metadata.first_ts, cloned.first_ts);
+    }
+
+    // ========================================================================
+    // ParsedSession Tests
+    // ========================================================================
+
+    #[test]
+    fn test_parsed_session_creation() {
+        let session = ParsedSession {
+            cwd: "/home/user/project".to_string(),
+            first_timestamp: Some("2026-01-15T10:00:00Z".to_string()),
+            last_timestamp: Some("2026-01-15T12:00:00Z".to_string()),
+            message_count: 10,
+            tool_usage: vec![
+                ToolUsage { tool_name: "Edit".to_string(), count: 5 },
+            ],
+            files_modified: vec!["src/main.rs".to_string()],
+            first_message: Some("Help me implement X".to_string()),
+        };
+
+        assert_eq!(session.cwd, "/home/user/project");
+        assert_eq!(session.message_count, 10);
+        assert_eq!(session.tool_usage.len(), 1);
+        assert_eq!(session.files_modified.len(), 1);
+    }
+
+    #[test]
+    fn test_parsed_session_clone() {
+        let session = ParsedSession {
+            cwd: "/path".to_string(),
+            first_timestamp: None,
+            last_timestamp: None,
+            message_count: 0,
+            tool_usage: vec![],
+            files_modified: vec![],
+            first_message: None,
+        };
+
+        let cloned = session.clone();
+
+        assert_eq!(session.cwd, cloned.cwd);
+        assert_eq!(session.message_count, cloned.message_count);
+    }
+
+    // ========================================================================
+    // parse_session_fast Tests
+    // ========================================================================
+
+    #[test]
+    fn test_parse_session_fast_valid_file() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+
+        // Write valid JSONL content
+        writeln!(temp_file, r#"{{"cwd":"/home/user/project","timestamp":"2026-01-15T10:00:00Z","type":"user","message":{{"role":"user","content":"This is a meaningful test message"}}}}"#).unwrap();
+        writeln!(temp_file, r#"{{"timestamp":"2026-01-15T10:30:00Z","type":"assistant","message":{{"role":"assistant","content":"Response here"}}}}"#).unwrap();
+        writeln!(temp_file, r#"{{"timestamp":"2026-01-15T11:00:00Z","type":"user","message":{{"role":"user","content":"Another meaningful message here"}}}}"#).unwrap();
+
+        let path = PathBuf::from(temp_file.path());
+        let result = parse_session_fast(&path);
+
+        assert!(result.is_some());
+        let metadata = result.unwrap();
+        assert_eq!(metadata.cwd, Some("/home/user/project".to_string()));
+        assert_eq!(metadata.first_ts, "2026-01-15T10:00:00Z");
+        assert_eq!(metadata.last_ts, "2026-01-15T11:00:00Z");
+        assert!(metadata.first_msg.is_some());
+        assert!(metadata.message_count >= 1);
+    }
+
+    #[test]
+    fn test_parse_session_fast_empty_file() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = PathBuf::from(temp_file.path());
+
+        let result = parse_session_fast(&path);
+
+        // Empty file should return None (no timestamps)
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_session_fast_nonexistent_file() {
+        let path = PathBuf::from("/nonexistent/path/to/file.jsonl");
+        let result = parse_session_fast(&path);
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_session_fast_invalid_json() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        writeln!(temp_file, "not valid json").unwrap();
+        writeln!(temp_file, "also not valid").unwrap();
+
+        let path = PathBuf::from(temp_file.path());
+        let result = parse_session_fast(&path);
+
+        // Invalid JSON should return None (no timestamps parsed)
+        assert!(result.is_none());
+    }
+
+    // ========================================================================
+    // parse_session_full Tests
+    // ========================================================================
+
+    #[test]
+    fn test_parse_session_full_valid_file() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+
+        writeln!(temp_file, r#"{{"cwd":"/home/user/project","timestamp":"2026-01-15T10:00:00Z","message":{{"role":"user","content":"This is a meaningful user message"}}}}"#).unwrap();
+        writeln!(temp_file, r#"{{"timestamp":"2026-01-15T10:30:00Z","message":{{"role":"assistant","content":[{{"type":"tool_use","name":"Edit","input":{{"file_path":"src/main.rs"}}}}]}}}}"#).unwrap();
+        writeln!(temp_file, r#"{{"timestamp":"2026-01-15T11:00:00Z","message":{{"role":"user","content":"Another meaningful message"}}}}"#).unwrap();
+
+        let path = PathBuf::from(temp_file.path());
+        let result = parse_session_full(&path);
+
+        assert!(result.is_some());
+        let session = result.unwrap();
+        assert_eq!(session.cwd, "/home/user/project");
+        assert!(session.first_timestamp.is_some());
+        assert!(session.last_timestamp.is_some());
+        assert!(session.message_count >= 1);
+    }
+
+    #[test]
+    fn test_parse_session_full_with_tool_usage() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+
+        writeln!(temp_file, r#"{{"cwd":"/project","timestamp":"2026-01-15T10:00:00Z","message":{{"role":"user","content":"Please help me with this task"}}}}"#).unwrap();
+        writeln!(temp_file, r#"{{"timestamp":"2026-01-15T10:05:00Z","message":{{"role":"assistant","content":[{{"type":"tool_use","name":"Read","input":{{"file_path":"README.md"}}}},{{"type":"tool_use","name":"Edit","input":{{"file_path":"src/lib.rs"}}}}]}}}}"#).unwrap();
+        writeln!(temp_file, r#"{{"timestamp":"2026-01-15T10:10:00Z","message":{{"role":"assistant","content":[{{"type":"tool_use","name":"Edit","input":{{"file_path":"src/main.rs"}}}}]}}}}"#).unwrap();
+
+        let path = PathBuf::from(temp_file.path());
+        let result = parse_session_full(&path);
+
+        assert!(result.is_some());
+        let session = result.unwrap();
+        // Should have tool usage recorded
+        assert!(!session.tool_usage.is_empty());
+        // Edit should have been used twice
+        let edit_usage = session.tool_usage.iter().find(|t| t.tool_name == "Edit");
+        assert!(edit_usage.is_some());
+        assert_eq!(edit_usage.unwrap().count, 2);
+    }
+
+    #[test]
+    fn test_parse_session_full_files_modified() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+
+        writeln!(temp_file, r#"{{"cwd":"/project","timestamp":"2026-01-15T10:00:00Z","message":{{"role":"user","content":"Please modify these files for me"}}}}"#).unwrap();
+        writeln!(temp_file, r#"{{"timestamp":"2026-01-15T10:05:00Z","message":{{"role":"assistant","content":[{{"type":"tool_use","name":"Write","input":{{"file_path":"new_file.rs"}}}},{{"type":"tool_use","name":"Edit","input":{{"file_path":"existing.rs"}}}}]}}}}"#).unwrap();
+
+        let path = PathBuf::from(temp_file.path());
+        let result = parse_session_full(&path);
+
+        assert!(result.is_some());
+        let session = result.unwrap();
+        // Should track files modified by Edit and Write
+        assert!(!session.files_modified.is_empty());
+    }
+
+    #[test]
+    fn test_parse_session_full_empty_file() {
+        let temp_file = NamedTempFile::new().unwrap();
+        let path = PathBuf::from(temp_file.path());
+
+        let result = parse_session_full(&path);
+
+        // Should return Some with defaults for empty file
+        assert!(result.is_some());
+        let session = result.unwrap();
+        assert_eq!(session.cwd, "");
+        assert!(session.first_timestamp.is_none());
+    }
+
+    #[test]
+    fn test_parse_session_full_nonexistent_file() {
+        let path = PathBuf::from("/nonexistent/path/to/file.jsonl");
+        let result = parse_session_full(&path);
+
+        assert!(result.is_none());
+    }
+
+    // ========================================================================
+    // SessionMessage Deserialization Tests
+    // ========================================================================
+
+    #[test]
+    fn test_session_message_deserialization() {
+        let json = r#"{
+            "cwd": "/home/user/project",
+            "timestamp": "2026-01-15T10:00:00Z",
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": "Hello"
+            }
+        }"#;
+
+        let msg: SessionMessage = serde_json::from_str(json).unwrap();
+
+        assert_eq!(msg.cwd, Some("/home/user/project".to_string()));
+        assert_eq!(msg.timestamp, Some("2026-01-15T10:00:00Z".to_string()));
+        assert_eq!(msg.msg_type, Some("user".to_string()));
+        assert!(msg.message.is_some());
+    }
+
+    #[test]
+    fn test_session_message_partial_deserialization() {
+        let json = r#"{"timestamp": "2026-01-15T10:00:00Z"}"#;
+
+        let msg: SessionMessage = serde_json::from_str(json).unwrap();
+
+        assert!(msg.cwd.is_none());
+        assert_eq!(msg.timestamp, Some("2026-01-15T10:00:00Z".to_string()));
+        assert!(msg.msg_type.is_none());
+        assert!(msg.message.is_none());
+    }
+
+    // ========================================================================
+    // ToolUseContent Deserialization Tests
+    // ========================================================================
+
+    #[test]
+    fn test_tool_use_content_deserialization() {
+        let json = r#"{
+            "type": "tool_use",
+            "name": "Edit",
+            "input": {"file_path": "src/main.rs"}
+        }"#;
+
+        let tool_use: ToolUseContent = serde_json::from_str(json).unwrap();
+
+        assert_eq!(tool_use.content_type, Some("tool_use".to_string()));
+        assert_eq!(tool_use.name, Some("Edit".to_string()));
+        assert!(tool_use.input.is_some());
     }
 }


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for recap-core modules
- Coverage improved from 26.82% → 64.79%
- 185 tests total, all passing

## Modules Tested

| Module | Coverage |
|--------|----------|
| auth.rs | 97.06% |
| models/mod.rs | 100% |
| session_parser.rs | 96.02% |
| worklog.rs | 76.47% |
| llm.rs | 55.56% |
| sync.rs | 33.02% |
| tempo.rs | 45.65% |

## Test Plan

- [x] `cargo test --package recap-core` - All 185 tests pass
- [x] `cargo llvm-cov --package recap-core` - Coverage verified

## Notes

- Remaining uncovered code requires database connections or HTTP mocking
- Future work: Add integration tests with mock database

Refs #5

🤖 Generated with [Claude Code](https://claude.ai/code)