### PR TITLE
chore: Release v2.2.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0-beta.4] - 2026-02-26
+
+### Added
+
+- **年度壓縮（Yearly Compaction）** - 新增 yearly 級別摘要，從 monthly summaries 彙總產生年度工作摘要
+- **歷史月份補壓縮** - Monthly compaction 現在會發現所有缺少摘要的歷史月份（之前只壓縮當月）
+- **Smart Re-compact** - Compaction 自動偵測 rule-based 摘要（"N 筆 commit" 格式）並用 LLM 重新生成
+
+### Fixed
+
+- **LLM 超時問題** - API timeout 從 30s 增至 120s，解決月度壓縮逾時失敗
+- **GPT-5 Reasoning Token 預算** - Responses API 加入 +2000 reasoning headroom，避免 reasoning 吃光 output budget
+- **LLM 輸出過於冗長** - Token budget 改為依 Settings 頁面 `summary_max_chars` 按比例縮放，prompt 強制精簡風格
+- **Usage Logs 時區錯誤** - SQLite UTC 時間戳改為顯示本地時間
+
+### Improved
+
+- **Compaction 並行度** - `COMPACTION_CONCURRENCY` 從 5 提升至 10
+- **移除冗餘 API 呼叫** - Compaction 不再於每次 cycle 呼叫 `test_connection()`
+
 ## [2.2.0-beta.3] - 2026-02-24
 
 ### Removed

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.2.0-beta.3"
+version = "2.2.0-beta.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/recap/recap"

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "recap-web",
   "private": true,
-  "version": "2.2.0-beta.3",
+  "version": "2.2.0-beta.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recap"
-version = "2.2.0-beta.3"
+version = "2.2.0-beta.4"
 description = "Recap - Work tracking and reporting tool"
 authors = ["Recap Team"]
 license = "MIT"

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Recap",
-  "version": "2.2.0-beta.3",
+  "version": "2.2.0-beta.4",
   "identifier": "com.recap.worklog",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Bump version to 2.2.0-beta.4
- Yearly compaction (monthly → yearly rollup)
- Historical monthly compaction (all past months, not just current)
- Smart re-compact: auto-detect and regenerate rule-based summaries with LLM
- LLM timeout 120s, GPT-5 reasoning headroom, token budget from Settings
- Compaction concurrency 5→10, removed test_connection overhead

## Test plan
- [x] Rust tests pass
- [x] Frontend tests pass (209)
- [x] Version consistent across 4 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)